### PR TITLE
Perf/reduce memory allocs

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -229,3 +229,22 @@ func TestUnmarshal(t *testing.T) {
 	})
 
 }
+
+func BenchmarkUnmarshal(b *testing.B) {
+	type QueryParams struct {
+		Text       string `query:"text"`
+		ID         string
+		Number     int64
+		Vat        float64
+		MiddleName *string
+	}
+
+	b.ReportAllocs()
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			var actual QueryParams
+			query.Unmarshal("text=TEXT&id=1234567&number=0&vat=1.1", &actual)
+		}
+	})
+}

--- a/encode.go
+++ b/encode.go
@@ -47,9 +47,10 @@ func (e *encode) do() (query string, err error) {
 		}
 	}()
 
-	for i := 0; i < e.obj.NumField(); i++ {
+	numFields := e.obj.NumField()
+	for i := 0; i < numFields; i++ {
 		e.pair(e.obj.Type().Field(i), e.obj.Field(i))
-		if i != e.obj.NumField()-1 {
+		if i != numFields-1 {
 			e.qb.WriteString(seperator)
 		}
 	}
@@ -59,12 +60,11 @@ func (e *encode) do() (query string, err error) {
 }
 
 func (e *encode) pair(fs reflect.StructField, v reflect.Value) {
-	bb := bytes.Buffer{}
 	key := e.key(fs)
-	bb.WriteString(key)
-	bb.WriteString(equal)
-	bb.WriteString(e.valueToString(v))
-	e.qb.Write(bb.Bytes())
+	value := e.valueToString(v)
+	e.qb.WriteString(key)
+	e.qb.WriteString(equal)
+	e.qb.WriteString(value)
 }
 
 func (e *encode) key(v reflect.StructField) string {
@@ -79,13 +79,9 @@ func (e *encode) key(v reflect.StructField) string {
 
 func (e *encode) valueToString(v reflect.Value) (s string) {
 
-	// reflect pointer
-	if v.Kind() == reflect.Pointer {
-		s = e.valueToString(v.Elem())
-		return
-	}
-
 	switch v.Kind() {
+	case reflect.Pointer:
+		s = e.valueToString(v.Elem())
 	case reflect.String:
 		s = v.String()
 	case reflect.Bool:

--- a/encode_test.go
+++ b/encode_test.go
@@ -184,3 +184,25 @@ func TestMarshal(t *testing.T) {
 	})
 
 }
+
+func BenchmarkMarshal(b *testing.B) {
+	type QueryParams struct {
+		text   string `query:"text"`
+		ID     string
+		Number int64
+		vat    float64
+	}
+
+	b.ReportAllocs()
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			query.Marshal(QueryParams{
+				text:   "TEXT",
+				ID:     "1234567",
+				Number: 0,
+				vat:    1.1,
+			})
+		}
+	})
+}

--- a/utils.go
+++ b/utils.go
@@ -15,8 +15,8 @@ const (
 var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
 
-func convertToSnakeCase(name string) string {
-	snake := matchFirstCap.ReplaceAllString(name, "${1}_${2}")
+func convertToSnakeCase(name string) (snake string) {
+	snake = matchFirstCap.ReplaceAllString(name, "${1}_${2}")
 	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
 	return strings.ToLower(snake)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,36 @@
+package query
+
+import "testing"
+
+func TestConvertToSnakeCase(t *testing.T) {
+	testCases := []struct {
+		name     string
+		expected string
+	}{
+		{"camelCase", "camel_case"},
+		{"PascalCase", "pascal_case"},
+		{"SCREAMING_SNAKE_CASE", "screaming_snake_case"},
+		{"snake_case", "snake_case"},
+		{"MixedCase123", "mixed_case123"},
+		{"", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := convertToSnakeCase(tc.name)
+			if result != tc.expected {
+				t.Errorf("Expected %s, but got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func BenchmarkConvertToSnakeCase(b *testing.B) {
+	b.ReportAllocs()
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			convertToSnakeCase("camelCase")
+		}
+	})
+}


### PR DESCRIPTION
- reduce memory allocation
- add utils test

**before**
```
goos: darwin
goarch: amd64
pkg: github.com/teerapon19/go-query-string
cpu: VirtualApple @ 2.50GHz
BenchmarkConvertToSnakeCase-8            4077366               284.7 ns/op           171 B/op          9 allocs/op
BenchmarkUnmarshal-8                     1200618               988.2 ns/op          1035 B/op         43 allocs/op
BenchmarkMarshal-8                       1458153               817.4 ns/op           829 B/op         40 allocs/op
PASS
ok      github.com/teerapon19/go-query-string   6.372s
```

**after**
```
goos: darwin
goarch: amd64
pkg: github.com/teerapon19/go-query-string
cpu: VirtualApple @ 2.50GHz
BenchmarkConvertToSnakeCase-8            4151071               283.3 ns/op           171 B/op          9 allocs/op
BenchmarkUnmarshal-8                     1203369               977.8 ns/op          1033 B/op         43 allocs/op
BenchmarkMarshal-8                       1643745               711.0 ns/op           561 B/op         36 allocs/op
PASS
ok      github.com/teerapon19/go-query-string   6.377s
```